### PR TITLE
Replace link to Gitter with link to Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Need help with Fastify? You've come to the right place!<br>
 #### Chat Resources
 
 If you would prefer to get help via live chat rather than the issue tracker in
-this repository, you can try [Gitter](https://gitter.im/fastify)!
+this repository, you can try our [Discord community](https://discord.gg/D3FZYPy)!
 
 #### Unofficial stackoverflow tag
 


### PR DESCRIPTION
It looks like the Fastify Gitter community has been disbanded ("0 Rooms 0 People"), so I've replaced it with a link to the active Discord server.
#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11) and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
