### PR TITLE
chore: remove help-wanted from exempt labels

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -4,7 +4,6 @@ daysUntilStale: 15
 daysUntilClose: 7
 # Issues with these labels will never be considered stale
 exemptLabels:
-  - "help wanted"
   - "good first issue"
 # Label to use when marking an issue as stale
 staleLabel: stale


### PR DESCRIPTION
Currently, all the issues created in `fastify/help` contain the `help wanted` label.